### PR TITLE
SSGDB-9: set up auto add reviewer git hub action

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,5 +10,3 @@ Please provide a brief description of the changes in this pull request.
 - [ ] I have updated the documentation(if applicable).
 
 **Screenshots (if applicable):**
-
-**Future Works:**

--- a/.github/workflows/auto-assign-reviewers.yml
+++ b/.github/workflows/auto-assign-reviewers.yml
@@ -1,0 +1,23 @@
+name: Auto add reviewers
+
+on:
+  pull_request_target:
+
+jobs:
+  add-reviewers:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Add reviewers
+        uses: actions/github-script@v5
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            const prNumber = context.payload.pull_request.number;
+            const reviewers = ["adrienne365", "FireL0ki", "Seolcita"]; 
+            github.pulls.requestReviewers({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber,
+              reviewers: reviewers
+            });

--- a/.github/workflows/auto-assign-reviewers.yml
+++ b/.github/workflows/auto-assign-reviewers.yml
@@ -14,7 +14,7 @@ jobs:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
             const prNumber = context.payload.pull_request.number;
-            const reviewers = ["adrienne365", "FireL0ki", "Seolcita"]; 
+            const reviewers = ["adrienne365", "FireL0ki"]; 
             github.pulls.requestReviewers({
               owner: context.repo.owner,
               repo: context.repo.repo,


### PR DESCRIPTION
## Pull Request

**Description:**

This PR sets up the Github action to auto add reviewers using a .yml file.

**Checklist:**

- [x] I have tested the changes locally.
- [x] I have updated the documentation(if applicable).

**Screenshots (if applicable):**

**Re: testing**
We won't know this works until it's been merged in and we create a new PR. But we can play around with the .yml file after that if we are having issues. This feature also isn't a necessity, so we don't need to prioritize it working, though it would be great if we can get it functioning.


Prior comments from @Seolcita 

GitHub Actions is a powerful automation tool integrated into the GitHub platform that helps automate tasks within the software development lifecycle. It can handle a wide array of workflows to automate processes such as CI/CD, testing, deploying, and managing project dependencies.

We have to create .github directory and add workflows directory. Then I can create .yml files for github actions. github action could be running tests automatically whenever we commit or create PR. It depends on how we configure in .yml file. Our github action is adding code reviewers automatically when we create pr instead of adding reviewers manually.

I found template for the github action and changed reviewer array. As I know there is no way to test before we merge it. I hope it works!

Here is Github Actions Docs link - https://docs.github.com/en/actions