### PR TITLE
screener popup functional but unstyled

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,7 +6,9 @@ import PageFooter from './components_true/PageFooter';
 import Navbar from './components_true/Navbar';
 import ScreenerQuestion from './components_true/ScreenerQ1';
 
+
 function App() {
+  
   return (
   <>
     <BrowserRouter>

--- a/src/components_true/Button.tsx
+++ b/src/components_true/Button.tsx
@@ -1,34 +1,18 @@
 import React from "react";
 
 interface Props {
-    border: string;
-    color: string;
-    children?: React.ReactNode;
-    height: string;
     onClick: () => void;
-    radius: string
-    width: string;
+    children: string;
+    style: string;
 }
 
 const Button: React.FC<Props> = ({
-    border,
-    color,
-    children,
-    height,
-    onClick, 
-    radius,
-    width
+    onClick,
+    children, 
   }) => {
     return (
         <button 
             onClick={onClick}
-            style={{
-                backgroundColor: color,
-                border,
-                borderRadius: radius,
-                height,
-                width
-            }}
         >
         {children}
         </button>

--- a/src/components_true/ScreenerPopUp.tsx
+++ b/src/components_true/ScreenerPopUp.tsx
@@ -1,0 +1,31 @@
+ import StyledButton from './StyledButton'
+ import Button from './Button'
+
+interface Popupcontent { 
+    onClick: () => void;
+    onClose: () => void;
+    onCancel: () => void;
+    message: string;
+}
+
+
+const ScreenerPopup: React.FC<Popupcontent> = ({message, onClick, onCancel, onClose}) => {
+   
+//handleCancel is an onClick for the cancel button and navigates home
+
+    return (
+        <section className="flex justify-end">
+                <div className="pr-6">
+                <p>{message}</p>
+                    <Button children='X' onClick={onClose} style={'bg-white border-2 text-black text-xs'}/>
+                    <StyledButton children='Cancel' onClick={onCancel} style={`bg-white border-2 border-lightPurple rounded-lg text-black text-xs md:text-base xl:text-xl font-normal leading-6 py-1.5 px-5 md:py-2 md:px-7`}/>
+                </div>
+                <div>
+                    <StyledButton children='Continue' onClick={onClick} style={`bg-lightPurple border-2 border-lightPurple rounded-lg text-black text-xs md:text-base xl:text-xl font-normal leading-6 p-1.5 px-5 md:py-2 md:px-7`}/>
+                </div>
+        
+        </section>
+    )
+}
+
+export default ScreenerPopup

--- a/src/components_true/ScreenerQ1.tsx
+++ b/src/components_true/ScreenerQ1.tsx
@@ -1,20 +1,39 @@
-import React from "react"
+import React, { useState }from "react"
 import { useNavigate } from "react-router-dom"
 import StyledButton from "./StyledButton";
+import ScreenerPopup from "./ScreenerPopUp";
+
 
 type QuestionProps = { 
     question: string;
 }
 
 const ScreenerQuestion = (props: QuestionProps) => {
+    const [showPopup, setShowPopup] = useState(false);
     const navigate = useNavigate()
+
     const handelRadioChange =  (event: React.ChangeEvent<HTMLInputElement>) => {
         const value = event.target.value
+        showPopup;
         console.log('Selected answer:', value)
     }
+const closePopup = () =>{
+    setShowPopup(false);
+};
+
+const handlePopupContinue = () => {
+    navigate('/')
+}
+//handleContinue is an onClick for the 'continue' button and moves on to next section, currently sends home
+//until next section is ready
+
+const handlePopupCancel = () => {
+    navigate('/')
+}
 
 const handleNextButton = () => {
-    navigate('/screenerquestion2')
+    setShowPopup(true);
+    console.log('next clicked')
 }
 
 const handleCancelButton = () => {
@@ -60,6 +79,13 @@ const handleCancelButton = () => {
                     <StyledButton children='Next' onClick={handleNextButton} style={`bg-lightPurple border-2 border-lightPurple rounded-lg text-black text-xs md:text-base xl:text-xl font-normal leading-6 p-1.5 px-5 md:py-2 md:px-7`}/>
                 </div>
             </section>
+                {showPopup && (
+                    <ScreenerPopup message="This app is not for you"
+                        onClose={closePopup}
+                        onClick={handlePopupContinue}
+                        onCancel={handlePopupCancel}
+                    />
+                )}
        </main> 
     ) 
 }

--- a/src/components_true/StyledButton.tsx
+++ b/src/components_true/StyledButton.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 interface ButtonProps {
     onClick?: () => void; // Optional onClick event handler
     children: React.ReactNode; // Required children (button label)
-    style?: string; // Optional className for additional styling
+    style: string; // Optional className for additional styling
   }
   
   const Button: React.FC<ButtonProps> = ({ onClick, children, style }) => {


### PR DESCRIPTION
## Description:

Pop-up created and shows when the 'Next' button is clicked
Pop-up has placeholder text
Pop-up has 3 buttons:
- Continue (currently navigates to home, will change once next phase of development is created)
- X (closes pop-up)
- Cancel (routes to home)

**STILL TO DO
- needs styling (Adrienne will push when added)
- pop-up conditional on selection of 'No' answer (Katherine will complete)
- 

## Testing / Acceptance Criteria

Deploy app, select 'No' for each screener question, verify presence of pop-up and buttons routing as expected (see above)

## Checklist:

- [ X ] I have tested the changes locally.
- [ X ] I have **requested review** from the other 2 developers on the project
