### PR TITLE
floating Start Assessment button added to the Landing Page

### DIFF
--- a/src/components_true/FloatingButton.tsx
+++ b/src/components_true/FloatingButton.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+
+
+const FloatingButton: React.FC = () => {
+    const navigate= useNavigate();
+
+  const handleFloatingButton = () => {
+    navigate('/screenerquestion1');
+}
+  return (
+    <button
+      className='fixed top-4 right-4 md:top-8 md:right-8 bg-lightPurple rounded-lg px-4 py-2.5 text-black text-lg font-semibold leading-6'
+      aria-label="Floating Action Button"
+      onClick={handleFloatingButton}
+
+    >Start Assessment
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth={2}
+          d="M12 4v16m8-8H4"
+        />
+    </button>
+  );
+};
+
+export default FloatingButton;

--- a/src/components_true/LandingPage.tsx
+++ b/src/components_true/LandingPage.tsx
@@ -4,6 +4,7 @@ import CareerSwitcher from './CareerSwitcher';
 import SimpleStepsBox from './SimpleStepsBox';
 import ImageWithText from './ImageWithText';
 import Header from './Header';
+import FloatingButton from './FloatingButton';
 
 import identify_your_transferable_skills from '../assets/identify_your_transerable_skills.png';
 import confidently_communicate_your_skills from '../assets/confidently_communicate_skills.png';
@@ -16,6 +17,7 @@ const LandingPage: React.FC = () => {
   return (
     // body div
     <>
+    <FloatingButton />
     <Header />
     <div className="flex flex-col h-full justify-center bg-white">
       <div className='flex justify-center items-center'>


### PR DESCRIPTION
## Description:

This component creates a floating button visible on the landing page which navigates to screener question 1

Add Screenshots (if applicable).

## Testing / Acceptance Criteria

Scroll up and down landing page and click 'Start Assessment' button at various points
*once this is accepted and merged we can delete the fixed 'Start Assessment' buttons on the landing page*

## Checklist:

- [x ] I have tested the changes locally.
- [x ] I have **requested review** from the other 2 developers on the project
